### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "include-media": "^1.4.9",
     "install": "^0.12.2",
     "node-sass": "^4.12.0",
-    "npm": "^6.9.0",
     "rc-tween-one": "^2.4.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION

Hello Aidanwang0309!

It seems like you have npm as one of your (dev-) dependency in fluzPurposePage.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
